### PR TITLE
fix: revert to node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     strategy:
       matrix:
-        node-version: [26]
+        node-version: [22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Revert node in release.yml to version 22.
Node 26 bundled undici with stricter validation on request dispatcher methods.
This breaks the semantic-release process.